### PR TITLE
Adds Handlebars case helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,66 @@ The list of “temples”, or files to generate when running the command. This c
 
 > Note: if you wish to use a key when defining `template` and `output`, you can wrap the values with quotes and use the same Handlebars syntax (e.g. “path/to/{{ module }}.js”).
 
+## **Templating**
+
+Temples uses Handlebars syntax for defining file templates and dynamic output paths. We've added a few helpers to provide more flexibility within the templates:
+
+### `camel`
+
+This helper will convert your variable to camelCase.
+
+```sh
+# Template
+{{ camel name }}
+```
+
+```sh
+# Input: { name: "BigButton" }
+bigButton
+```
+
+### `kebab`
+
+This helper will convert your variable to kebab-case.
+
+```sh
+# Template
+{{ kebab name }}
+```
+
+```sh
+# Input: { name: "bigButton" }
+big-button
+```
+
+### `snake`
+
+This helper will convert your variable to snake_case.
+
+```sh
+# Template
+{{ snake name }}
+```
+
+```sh
+# Input: { name: "big-button" }
+big_button
+```
+
+### `title`
+
+This helper will convert your variable to TitleCase.
+
+```sh
+# Template
+{{ snake name }}
+```
+
+```sh
+# Input: { name: "big_button" }
+BigButton
+```
+
 ## **Example**
 
 This is an example `.temples.yaml` file for a React project:
@@ -111,17 +171,17 @@ component:
   # All paths are relative to src folder
   base: ./src
   temples:
-  # Component entry point file
+    # Component entry point file
     - template: component.template
       output: "components/{{ name }}/index.js"
       default:
         name: Component
 
-  # Component CSS stylesheet
+    # Component CSS stylesheet
     - template: styles.template
-      output: "components/{{ name }}/styles.css"
-      
-  # Component test file
+      output: "components/{{ name }}/{{ camel name }}.module.scss"
+
+    # Component test file
     - template: test.template
       output: "components/{{ name }}/test.js"
 ```
@@ -130,13 +190,21 @@ component:
 
 ```
 import React from 'react';
-import styles from './styles.css';
+import styles from './{{ camel name }}.module.scss';
 
 const {{ name }} = () => {
 	return null;
 };
 
 export default {{ name }};
+```
+
+`styles.template`
+
+```
+.{{ kebab name }} {
+
+}
 ```
 
 `test.template`
@@ -155,4 +223,5 @@ temples component --name Button
 ```
 
 ## **License**
+
 Copyright © 2020 - present, [Gino Jacob](https://ginojacob.com). MIT License.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "temples",
-  "version": "1.1.0",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -1,5 +1,5 @@
-import Handlebars from "handlebars";
-import { camelCase, kebabCase, snakeCase, startCase } from "lodash";
+import Handlebars from 'handlebars';
+import { camelCase, kebabCase, snakeCase, startCase } from 'lodash';
 
 /**
  * Registers custom casing helpers to the Handlebars environment.
@@ -8,24 +8,24 @@ import { camelCase, kebabCase, snakeCase, startCase } from "lodash";
  */
 const registerHelpers = () => {
   // Registers a camelCase helper for the template.
-  Handlebars.registerHelper("camel", (string) => {
+  Handlebars.registerHelper('camel', (string) => {
     return camelCase(string);
   });
 
   // Registers a kebab-case helper for the template.
-  Handlebars.registerHelper("kebab", (string) => {
+  Handlebars.registerHelper('kebab', (string) => {
     return kebabCase(string);
   });
 
   // Registers a snake_case helper for the template.
-  Handlebars.registerHelper("snake", (string) => {
+  Handlebars.registerHelper('snake', (string) => {
     return snakeCase(string);
   });
 
   // Registers a TitleCase helper for the template.
-  Handlebars.registerHelper("title", (string) => {
+  Handlebars.registerHelper('title', (string) => {
     const casedString = startCase(string);
-    return casedString.replace(/\s/g, "");
+    return casedString.replace(/\s/g, '');
   });
 };
 

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -1,4 +1,33 @@
-import { compile } from 'handlebars';
+import Handlebars from "handlebars";
+import { camelCase, kebabCase, snakeCase, startCase } from "lodash";
+
+/**
+ * Registers custom casing helpers to the Handlebars environment.
+ *
+ * @see https://handlebarsjs.com/api-reference/runtime.html#handlebars-registerhelper-name-helper
+ */
+const registerHelpers = () => {
+  // Registers a camelCase helper for the template.
+  Handlebars.registerHelper("camel", (string) => {
+    return camelCase(string);
+  });
+
+  // Registers a kebab-case helper for the template.
+  Handlebars.registerHelper("kebab", (string) => {
+    return kebabCase(string);
+  });
+
+  // Registers a snake_case helper for the template.
+  Handlebars.registerHelper("snake", (string) => {
+    return snakeCase(string);
+  });
+
+  // Registers a TitleCase helper for the template.
+  Handlebars.registerHelper("title", (string) => {
+    const casedString = startCase(string);
+    return casedString.replace(/\s/g, "");
+  });
+};
 
 /**
  * Parse source with given mapping, overriding the default
@@ -10,7 +39,8 @@ import { compile } from 'handlebars';
  * @returns {String} parsed source
  */
 export const parse = (source, mapping = {}, defaultMapping = {}) => {
-  const template = compile(source);
+  registerHelpers();
+  const template = Handlebars.compile(source);
   return template({ ...defaultMapping, ...mapping });
 };
 

--- a/src/parser/test.js
+++ b/src/parser/test.js
@@ -1,29 +1,57 @@
-import parse from '.';
+import parse from ".";
 
-describe('parser', () => {
-  it('applies mapping if provided', () => {
-    const source = 'Hello, {{ name }}';
-    const mapping = { name: 'Temple' };
+describe("parser", () => {
+  it("applies mapping if provided", () => {
+    const source = "Hello, {{ name }}";
+    const mapping = { name: "Temple" };
 
     expect(parse(source, mapping)).toBe(`Hello, ${mapping.name}`);
   });
 
-  it('applies defaultMapping if provided', () => {
-    const source = 'Hello, {{ name }}';
-    const defaultMapping = { name: 'Temple' };
+  it("applies defaultMapping if provided", () => {
+    const source = "Hello, {{ name }}";
+    const defaultMapping = { name: "Temple" };
 
     expect(parse(source, {}, defaultMapping)).toBe(
       `Hello, ${defaultMapping.name}`
     );
   });
 
-  it('overrides defaultMapping with mapping', () => {
-    const source = '{{ greeting }}, {{ name }}';
-    const mapping = { name: 'not Temple' };
-    const defaultMapping = { greeting: 'Hello', name: 'Temple' };
+  it("overrides defaultMapping with mapping", () => {
+    const source = "{{ greeting }}, {{ name }}";
+    const mapping = { name: "not Temple" };
+    const defaultMapping = { greeting: "Hello", name: "Temple" };
 
     expect(parse(source, mapping, defaultMapping)).toBe(
       `${defaultMapping.greeting}, ${mapping.name}`
     );
+  });
+
+  it("applies camelCase helper to template", () => {
+    const source = "Hello, {{ camel name }}";
+    const mapping = { name: "BigButton" };
+
+    expect(parse(source, mapping)).toBe(`Hello, bigButton`);
+  });
+
+  it("applies kebab-case helper to template", () => {
+    const source = "Hello, {{ kebab name }}";
+    const mapping = { name: "BigButton" };
+
+    expect(parse(source, mapping)).toBe(`Hello, big-button`);
+  });
+
+  it("applies snake_case helper to template", () => {
+    const source = "Hello, {{ snake name }}";
+    const mapping = { name: "BigButton" };
+
+    expect(parse(source, mapping)).toBe(`Hello, big_button`);
+  });
+
+  it("applies TitleCase helper to template", () => {
+    const source = "Hello, {{ title name }}";
+    const mapping = { name: "big-button" };
+
+    expect(parse(source, mapping)).toBe(`Hello, BigButton`);
   });
 });

--- a/src/parser/test.js
+++ b/src/parser/test.js
@@ -1,56 +1,56 @@
-import parse from ".";
+import parse from '.';
 
-describe("parser", () => {
-  it("applies mapping if provided", () => {
-    const source = "Hello, {{ name }}";
-    const mapping = { name: "Temple" };
+describe('parser', () => {
+  it('applies mapping if provided', () => {
+    const source = 'Hello, {{ name }}';
+    const mapping = { name: 'Temple' };
 
     expect(parse(source, mapping)).toBe(`Hello, ${mapping.name}`);
   });
 
-  it("applies defaultMapping if provided", () => {
-    const source = "Hello, {{ name }}";
-    const defaultMapping = { name: "Temple" };
+  it('applies defaultMapping if provided', () => {
+    const source = 'Hello, {{ name }}';
+    const defaultMapping = { name: 'Temple' };
 
     expect(parse(source, {}, defaultMapping)).toBe(
       `Hello, ${defaultMapping.name}`
     );
   });
 
-  it("overrides defaultMapping with mapping", () => {
-    const source = "{{ greeting }}, {{ name }}";
-    const mapping = { name: "not Temple" };
-    const defaultMapping = { greeting: "Hello", name: "Temple" };
+  it('overrides defaultMapping with mapping', () => {
+    const source = '{{ greeting }}, {{ name }}';
+    const mapping = { name: 'not Temple' };
+    const defaultMapping = { greeting: 'Hello', name: 'Temple' };
 
     expect(parse(source, mapping, defaultMapping)).toBe(
       `${defaultMapping.greeting}, ${mapping.name}`
     );
   });
 
-  it("applies camelCase helper to template", () => {
-    const source = "Hello, {{ camel name }}";
-    const mapping = { name: "BigButton" };
+  it('applies camelCase helper to template', () => {
+    const source = 'Hello, {{ camel name }}';
+    const mapping = { name: 'BigButton' };
 
     expect(parse(source, mapping)).toBe(`Hello, bigButton`);
   });
 
-  it("applies kebab-case helper to template", () => {
-    const source = "Hello, {{ kebab name }}";
-    const mapping = { name: "BigButton" };
+  it('applies kebab-case helper to template', () => {
+    const source = 'Hello, {{ kebab name }}';
+    const mapping = { name: 'BigButton' };
 
     expect(parse(source, mapping)).toBe(`Hello, big-button`);
   });
 
-  it("applies snake_case helper to template", () => {
-    const source = "Hello, {{ snake name }}";
-    const mapping = { name: "BigButton" };
+  it('applies snake_case helper to template', () => {
+    const source = 'Hello, {{ snake name }}';
+    const mapping = { name: 'BigButton' };
 
     expect(parse(source, mapping)).toBe(`Hello, big_button`);
   });
 
-  it("applies TitleCase helper to template", () => {
-    const source = "Hello, {{ title name }}";
-    const mapping = { name: "big-button" };
+  it('applies TitleCase helper to template', () => {
+    const source = 'Hello, {{ title name }}';
+    const mapping = { name: 'big-button' };
 
     expect(parse(source, mapping)).toBe(`Hello, BigButton`);
   });


### PR DESCRIPTION
# Description

When generating React components, my file structure usually looks something like this:
```
- ComponentName/
  |- index.js
  |- componentName.module.scss
```

This PR adds some simple case [helpers to Handlebars](https://handlebarsjs.com/api-reference/runtime.html#handlebars-registerhelper-name-helper) that makes this possible!

## What This Does

- Adds `camel` helper for converting to camelCase
- Adds `kebab` helper for converting to kebab-case
- Adds `snake` helper for converting to snake_case
- Adds `title` helper for converting to TitleCase
- Updates `README` to include some examples of new templating helpers

> _Note:_ I updated the README example to use the new helpers, but feel free to revert to the original one!